### PR TITLE
Added AllowUserVariables to the connection string

### DIFF
--- a/Models/MySqlDb.cs
+++ b/Models/MySqlDb.cs
@@ -26,8 +26,8 @@
         public MySqlDb(MySqlConfig config) : this(config.ToString())
             { }
 
-        public MySqlDb(string hostname, string username, string password, string database, int port = 3306, string sslmode = "none")
-            : this($"Server={hostname};Database={database};port={port};User Id={username};password={password};SslMode={sslmode};")
+        public MySqlDb(string hostname, string username, string password, string database, int port = 3306, string sslmode = "none", bool userVariables = false)
+            : this($"Server={hostname};Database={database};port={port};User Id={username};password={password};SslMode={sslmode};AllowUserVariables={userVariables}")
             { }
 
         public MySqlDb Table(string name)


### PR DESCRIPTION
In this pull request I added the option 'AllowUserVariables' to the connection string.

By default it is set to false which is the default behavior if you don't include AllowUserVariables in the connection string.